### PR TITLE
Early return in utils if node does not have tagName

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -21,8 +21,13 @@ function loadScrollyteller(name, className, markerName) {
     let node = firstNode.nextSibling;
     let nodes = [];
     let hasMoreContent = true;
+
     while (hasMoreContent && node) {
-      if (node.tagName && (node.getAttribute('name') || '').indexOf(`endscrollyteller`) > -1) {
+      if (!node.tagName) {
+        node = node.nextSibling;
+        continue;
+      }
+      if ((node.getAttribute('name') || '').indexOf(`endscrollyteller`) > -1) {
         hasMoreContent = false;
       } else {
         [].slice.apply(node.querySelectorAll('.inline-caption')).forEach(child => {


### PR DESCRIPTION
If any node between the first and the last nodes of the scrollyteller is
followed by text, or whitespace (like a carriage return) the call to
nextSibling returns a Text node which does not have a `tagName`
property, and does have a `querySelectorAll` method.

When `querySelectorAll` is called, in the changes introduced in commit
0a43e75 the text nodes cause an exception like this:
```
TypeError: s.querySelectorAll is not a function
```

The inability to have newlines between nodes, makes it very difficult to
manually write markup as all the marks have to be on the same
line.

It might be better to only reject if node does not respond to
`querySelectorAll`. I'm not sure if a Text node is valid as a
scrollyTeller panel node.