### PR TITLE
Convert to PureComponent to avoid re-renders

### DIFF
--- a/src/Scrollyteller/index.js
+++ b/src/Scrollyteller/index.js
@@ -4,7 +4,7 @@ const assign = require('object-assign');
 
 const styles = require('./index.scss');
 
-class Scrollyteller extends React.Component {
+class Scrollyteller extends React.PureComponent {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
I noticed that custom panel was re-rendering (or at least re-running component logic) on every scroll event. This seems to fix it. May help with performance issues also with dynamically updating panel content too down the track.