### PR TITLE
Fix jank at end of scrollyteller

### DIFF
--- a/src/Scrollyteller/index.scss
+++ b/src/Scrollyteller/index.scss
@@ -40,6 +40,7 @@
   position: absolute;
   bottom: 0;
   height: 100vh !important;
+  overflow: hidden;
 }
 
 .firstPanel {


### PR DESCRIPTION
When the viz switches from `.during` to `.after` there was some jank where the viz container got a scrollbar for some reason. This fixes that.