### PR TITLE
Target panel (seems to be 2nd) - also onScroll Fix

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,7 @@
+# .prettierrc or .prettierrc.yaml
+trailingComma: "none"
+tabWidth: 2
+semi: true
+singleQuote: true
+printWidth: 100
+jsxBracketSameLine: true

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ module.exports = Story;
 
 ## Customising
 
-The `Scrollyteller` can also takes a `panelClassName` prop which it will pass to each panel component for customising the look.
+The `Scrollyteller` can take a `panelClassName` prop which it will pass to each panel component for customising the look.
+It can also take `firstPanelClassName` and `lastPanelClassName` props which it will pass to the respective panel components, for customising their specific looks.
 
 To completely customise how panels are rendered you can pass in `panelComponent`. The main requirement for this component is that it calls `props.reference` with a ref to its outermost wrapper.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6789,6 +6789,46 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.11.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+          "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==",
+          "dev": true
+        }
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "compile": "webpack",
-    "prepublishOnly": "npm run compile && npm run test"
+    "prepublishOnly": "npm run compile && npm run test",
+    "dev": "webpack --watch"
   },
   "keywords": [
     "react",

--- a/src/Panel/index.scss
+++ b/src/Panel/index.scss
@@ -14,11 +14,11 @@
 
   width: 61.25rem;
 
-  &:nth-of-type(2) {
+  &.first {
     margin-top: 100vh;
   }
 
-  &:last-of-type {
+  &.last {
     margin-bottom: 100vh;
   }
 

--- a/src/Panel/index.scss
+++ b/src/Panel/index.scss
@@ -14,7 +14,7 @@
 
   width: 61.25rem;
 
-  &:first-of-type {
+  &:nth-of-type(2) {
     margin-top: 100vh;
   }
 

--- a/src/Scrollyteller/index.scss
+++ b/src/Scrollyteller/index.scss
@@ -38,14 +38,6 @@
   overflow: hidden;
 }
 
-.firstPanel {
-  padding-top: 100vh;
-}
-
-.lastPanel {
-  padding-bottom: 100vh;
-}
-
 @media only screen and (max-width: 667px) {
   .base {
     height: 100%;

--- a/src/Scrollyteller/index.test.tsx
+++ b/src/Scrollyteller/index.test.tsx
@@ -42,4 +42,16 @@ describe('Scrollyteller', () => {
     const graphic = container.querySelector('.graphic');
     expect(container.firstElementChild.childNodes.item(1)).toBe(graphic);
   });
+
+  it('can add first/last className to the first/last panel', () => {
+    const { container } = render(
+      <Scrollyteller panels={panels}>
+        <div id="graphic" />
+      </Scrollyteller>
+    );
+
+    const panel = container.querySelector('p').parentElement;
+    expect(panel.className.indexOf('first')).toBeGreaterThan(-1);
+    expect(panel.className.indexOf('last')).toBeGreaterThan(-1);
+  });
 });

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as assign from 'object-assign';
 
 import Panel from '../Panel';
+import * as panelStyles from '../Panel/index.scss';
 import * as styles from './index.scss';
 
 interface Props {
@@ -11,10 +12,14 @@ interface Props {
   onMarker?: (config: any, id: string) => void;
   className?: string;
   panelClassName?: string;
+  firstPanelClassName?: string;
+  lastPanelClassName?: string;
   panelComponent?: any;
 }
 
 const references: any[] = [];
+
+const cn = (candidates: any[]) => candidates.filter((x: any): string => x).join(' ');
 
 export default (props: Props) => {
   props = assign(
@@ -94,14 +99,22 @@ export default (props: Props) => {
   // RENDER
 
   const graphic = <div className={`${styles.graphic} ${styles[backgroundAttachment]}`}>{props.children}</div>;
+  const numPanels = props.panels.length;
 
   return (
     <div ref={base} className={`${styles.base} ${props.className || ''}`}>
       {!props.config.graphicInFront && graphic}
 
-      {props.panels.map(panel => {
+      {props.panels.map((panel, index) => {
         return React.createElement(props.panelComponent || Panel, {
-          className: `${props.panelClassName || ''} ${panel.className || ''}`,
+          className: cn([
+            props.panelClassName,
+            panel.className,
+            index === 0 && props.firstPanelClassName,
+            index === 0 && panelStyles.first,
+            index === numPanels - 1 && props.lastPanelClassName,
+            index === numPanels - 1 && panelStyles.last
+          ]),
           key: typeof panel.key !== 'undefined' ? panel.key : panel.id,
           config: assign({}, props.config, panel.config || {}),
           nodes: panel.nodes,

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
-import * as assign from "object-assign";
+import * as React from 'react';
+import * as assign from 'object-assign';
 
-import Panel from "../Panel";
-import * as panelStyles from "../Panel/index.scss";
-import * as styles from "./index.scss";
+import Panel from '../Panel';
+import * as panelStyles from '../Panel/index.scss';
+import * as styles from './index.scss';
 
 interface Props {
   children: any;
@@ -20,8 +20,7 @@ interface Props {
 
 const references: any[] = [];
 
-const cn = (candidates: any[]) =>
-  candidates.filter((x: any): string => x).join(" ");
+const cn = (candidates: any[]) => candidates.filter((x: any): string => x).join(' ');
 
 const Scrollyteller = React.memo((props: Props) => {
   props = assign(
@@ -36,9 +35,7 @@ const Scrollyteller = React.memo((props: Props) => {
   const base = React.useRef(null);
 
   let currentPanel: any = null;
-  const [backgroundAttachment, setBackgroundAttachment] = React.useState(
-    "before"
-  );
+  const [backgroundAttachment, setBackgroundAttachment] = React.useState('before');
 
   // Track panel divs so we know which one is the current one
   function reference(panel: any, element: any) {
@@ -51,16 +48,14 @@ const Scrollyteller = React.memo((props: Props) => {
     if (references.length === 0) return;
 
     // Work out which panel is the current one
-    const fold =
-      window.innerHeight * (config.waypoint ? config.waypoint / 100 : 0.8);
+    const fold = window.innerHeight * (config.waypoint ? config.waypoint / 100 : 0.8);
     const referencesAboveTheFold = references.filter((r: any) => {
       if (!r.element) return false;
       const box = r.element.getBoundingClientRect();
       return box.height !== 0 && box.top < fold;
     });
 
-    let closestReference =
-      referencesAboveTheFold[referencesAboveTheFold.length - 1];
+    let closestReference = referencesAboveTheFold[referencesAboveTheFold.length - 1];
     if (!closestReference) closestReference = references[0];
 
     if (currentPanel !== closestReference.panel) {
@@ -75,11 +70,11 @@ const Scrollyteller = React.memo((props: Props) => {
 
       let sticky;
       if (bounds.top > 0) {
-        sticky = "before";
+        sticky = 'before';
       } else if (bounds.bottom < window.innerHeight) {
-        sticky = "after";
+        sticky = 'after';
       } else {
-        sticky = "during";
+        sticky = 'during';
       }
 
       setBackgroundAttachment(sticky);
@@ -95,31 +90,26 @@ const Scrollyteller = React.memo((props: Props) => {
     // Make sure Twitter cards aren't too wide on mobile
     setTimeout(() => {
       [].slice
-        .call(
-          document.querySelectorAll(`${styles.base} .twitter-tweet-rendered`)
-        )
+        .call(document.querySelectorAll(`${styles.base} .twitter-tweet-rendered`))
         .forEach((card: any) => {
-          card.style.setProperty("width", "100%");
+          card.style.setProperty('width', '100%');
         });
     }, 1000);
 
-    window.addEventListener("scroll", onScroll);
+    window.addEventListener('scroll', onScroll);
     return () => {
-      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener('scroll', onScroll);
     };
   }, []);
 
   // RENDER
-
   const graphic = (
-    <div className={`${styles.graphic} ${styles[backgroundAttachment]}`}>
-      {props.children}
-    </div>
+    <div className={`${styles.graphic} ${styles[backgroundAttachment]}`}>{props.children}</div>
   );
   const numPanels = props.panels.length;
 
   return (
-    <div ref={base} className={`${styles.base} ${props.className || ""}`}>
+    <div ref={base} className={`${styles.base} ${props.className || ''}`}>
       {!props.config.graphicInFront && graphic}
 
       {props.panels.map((panel, index) => {
@@ -132,7 +122,7 @@ const Scrollyteller = React.memo((props: Props) => {
             index === numPanels - 1 && props.lastPanelClassName,
             index === numPanels - 1 && panelStyles.last
           ]),
-          key: typeof panel.key !== "undefined" ? panel.key : panel.id,
+          key: typeof panel.key !== 'undefined' ? panel.key : panel.id,
           config: assign({}, props.config, panel.config || {}),
           nodes: panel.nodes,
           reference: (element: any) => reference(panel, element)

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -15,7 +15,7 @@ interface Props {
   firstPanelClassName?: string;
   lastPanelClassName?: string;
   panelComponent?: any;
-  fireInitialMarker?: boolean;
+  dontFireInitialMarker?: boolean;
 }
 
 const references: any[] = [];
@@ -45,7 +45,7 @@ const Scrollyteller = React.memo((props: Props) => {
     references.push({ panel, element });
   }
 
-  function onScroll(options: any) {
+  function onScroll(event: any, dontFireInitialMarker?: boolean) {
     const { config, onMarker } = props;
 
     if (references.length === 0) return;
@@ -65,8 +65,8 @@ const Scrollyteller = React.memo((props: Props) => {
 
     if (currentPanel !== closestReference.panel) {
       currentPanel = closestReference.panel;
-      if (options.dontFireMarker) console.log("Not firing");
-      else onMarker(closestReference.panel.config, closestReference.panel.id);
+      if (!dontFireInitialMarker)
+        onMarker(closestReference.panel.config, closestReference.panel.id);
     }
 
     // Work out if the background should be fixed or not
@@ -90,10 +90,7 @@ const Scrollyteller = React.memo((props: Props) => {
     // Safari tries to do things before styling has kicked in
     // so lets wait for a split second before measuring.
     // Fires inital marker on page load, unless overridden
-    setTimeout(
-      () => onScroll({ dontFireMarker: !props.fireInitialMarker }),
-      100
-    );
+    setTimeout(() => onScroll(null, props.dontFireInitialMarker), 100);
 
     // Make sure Twitter cards aren't too wide on mobile
     setTimeout(() => {

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
-import * as assign from 'object-assign';
+import * as React from "react";
+import * as assign from "object-assign";
 
-import Panel from '../Panel';
-import * as panelStyles from '../Panel/index.scss';
-import * as styles from './index.scss';
+import Panel from "../Panel";
+import * as panelStyles from "../Panel/index.scss";
+import * as styles from "./index.scss";
 
 interface Props {
   children: any;
@@ -15,13 +15,15 @@ interface Props {
   firstPanelClassName?: string;
   lastPanelClassName?: string;
   panelComponent?: any;
+  fireInitialMarker?: boolean;
 }
 
 const references: any[] = [];
 
-const cn = (candidates: any[]) => candidates.filter((x: any): string => x).join(' ');
+const cn = (candidates: any[]) =>
+  candidates.filter((x: any): string => x).join(" ");
 
-export default (props: Props) => {
+const Scrollyteller = React.memo((props: Props) => {
   props = assign(
     {},
     {
@@ -33,76 +35,90 @@ export default (props: Props) => {
 
   const base = React.useRef(null);
 
-  const [currentPanel, setCurrentPanel] = React.useState(null);
-  const [backgroundAttachment, setBackgroundAttachment] = React.useState('before');
+  let currentPanel:any = null;
+  const [backgroundAttachment, setBackgroundAttachment] = React.useState(
+    "before"
+  );
 
   // Track panel divs so we know which one is the current one
   function reference(panel: any, element: any) {
     references.push({ panel, element });
   }
 
-  React.useEffect(() => {
-    function onScroll() {
-      const { config, onMarker } = props;
+  function onScroll() {
+    const { config, onMarker } = props;
 
-      if (references.length === 0) return;
+    if (references.length === 0) return;
 
-      // Work out which panel is the current one
-      const fold = window.innerHeight * (config.waypoint ? config.waypoint / 100 : 0.8);
-      const referencesAboveTheFold = references.filter((r: any) => {
-        if (!r.element) return false;
-        const box = r.element.getBoundingClientRect();
-        return box.height !== 0 && box.top < fold;
-      });
+    // Work out which panel is the current one
+    const fold =
+      window.innerHeight * (config.waypoint ? config.waypoint / 100 : 0.8);
+    const referencesAboveTheFold = references.filter((r: any) => {
+      if (!r.element) return false;
+      const box = r.element.getBoundingClientRect();
+      return box.height !== 0 && box.top < fold;
+    });
 
-      let closestReference = referencesAboveTheFold[referencesAboveTheFold.length - 1];
-      if (!closestReference) closestReference = references[0];
-      if (currentPanel !== closestReference.panel) {
-        setCurrentPanel(closestReference.panel);
-        onMarker(closestReference.panel.config, closestReference.panel.id);
-      }
+    let closestReference =
+      referencesAboveTheFold[referencesAboveTheFold.length - 1];
+    if (!closestReference) closestReference = references[0];
 
-      // Work out if the background should be fixed or not
-      if (base.current) {
-        const bounds = base.current.getBoundingClientRect();
-
-        let sticky;
-        if (bounds.top > 0) {
-          sticky = 'before';
-        } else if (bounds.bottom < window.innerHeight) {
-          sticky = 'after';
-        } else {
-          sticky = 'during';
-        }
-
-        setBackgroundAttachment(sticky);
-      }
+    if (currentPanel !== closestReference.panel) {
+      currentPanel = closestReference.panel;
+      onMarker(closestReference.panel.config, closestReference.panel.id);
     }
 
+    // Work out if the background should be fixed or not
+    if (base.current) {
+      const bounds = base.current.getBoundingClientRect();
+
+      let sticky;
+      if (bounds.top > 0) {
+        sticky = "before";
+      } else if (bounds.bottom < window.innerHeight) {
+        sticky = "after";
+      } else {
+        sticky = "during";
+      }
+
+      setBackgroundAttachment(sticky);
+    }
+  }
+
+  React.useEffect(() => {
     // Safari tries to do things before styling has kicked in
-    // so lets wait for a split second before measuring
+    // so lets wait for a split second before measuring.
+    // Fires inital marker on page load, unless overridden
     setTimeout(() => onScroll(), 100);
 
     // Make sure Twitter cards aren't too wide on mobile
     setTimeout(() => {
-      [].slice.call(document.querySelectorAll(`${styles.base} .twitter-tweet-rendered`)).forEach((card: any) => {
-        card.style.setProperty('width', '100%');
-      });
+      [].slice
+        .call(
+          document.querySelectorAll(`${styles.base} .twitter-tweet-rendered`)
+        )
+        .forEach((card: any) => {
+          card.style.setProperty("width", "100%");
+        });
     }, 1000);
 
-    window.addEventListener('scroll', onScroll);
+    window.addEventListener("scroll", onScroll);
     return () => {
-      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener("scroll", onScroll);
     };
   }, []);
 
   // RENDER
 
-  const graphic = <div className={`${styles.graphic} ${styles[backgroundAttachment]}`}>{props.children}</div>;
+  const graphic = (
+    <div className={`${styles.graphic} ${styles[backgroundAttachment]}`}>
+      {props.children}
+    </div>
+  );
   const numPanels = props.panels.length;
 
   return (
-    <div ref={base} className={`${styles.base} ${props.className || ''}`}>
+    <div ref={base} className={`${styles.base} ${props.className || ""}`}>
       {!props.config.graphicInFront && graphic}
 
       {props.panels.map((panel, index) => {
@@ -115,7 +131,7 @@ export default (props: Props) => {
             index === numPanels - 1 && props.lastPanelClassName,
             index === numPanels - 1 && panelStyles.last
           ]),
-          key: typeof panel.key !== 'undefined' ? panel.key : panel.id,
+          key: typeof panel.key !== "undefined" ? panel.key : panel.id,
           config: assign({}, props.config, panel.config || {}),
           nodes: panel.nodes,
           reference: (element: any) => reference(panel, element)
@@ -125,4 +141,6 @@ export default (props: Props) => {
       {props.config.graphicInFront && graphic}
     </div>
   );
-};
+});
+
+export default Scrollyteller;

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -35,7 +35,7 @@ const Scrollyteller = React.memo((props: Props) => {
 
   const base = React.useRef(null);
 
-  let currentPanel:any = null;
+  let currentPanel: any = null;
   const [backgroundAttachment, setBackgroundAttachment] = React.useState(
     "before"
   );
@@ -45,7 +45,7 @@ const Scrollyteller = React.memo((props: Props) => {
     references.push({ panel, element });
   }
 
-  function onScroll() {
+  function onScroll(options: any) {
     const { config, onMarker } = props;
 
     if (references.length === 0) return;
@@ -65,7 +65,8 @@ const Scrollyteller = React.memo((props: Props) => {
 
     if (currentPanel !== closestReference.panel) {
       currentPanel = closestReference.panel;
-      onMarker(closestReference.panel.config, closestReference.panel.id);
+      if (options.dontFireMarker) console.log("Not firing");
+      else onMarker(closestReference.panel.config, closestReference.panel.id);
     }
 
     // Work out if the background should be fixed or not
@@ -89,7 +90,10 @@ const Scrollyteller = React.memo((props: Props) => {
     // Safari tries to do things before styling has kicked in
     // so lets wait for a split second before measuring.
     // Fires inital marker on page load, unless overridden
-    setTimeout(() => onScroll(), 100);
+    setTimeout(
+      () => onScroll({ dontFireMarker: !props.fireInitialMarker }),
+      100
+    );
 
     // Make sure Twitter cards aren't too wide on mobile
     setTimeout(() => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -77,7 +77,11 @@ function loadPanels(nodes: any[], initialMarker: any, name: string) {
 
   // Check the section nodes for panels and marker content
   nodes.forEach((node, index) => {
-    if (node.tagName === 'A' && node.getAttribute('name') && node.getAttribute('name').indexOf(name) === 0) {
+    if (
+      node.tagName === 'A' &&
+      node.getAttribute('name') &&
+      node.getAttribute('name').indexOf(name) === 0
+    ) {
       // Found a new marker so we should commit the last one
       pushPanel();
 


### PR DESCRIPTION
Hey just making this change to see if anyone else is getting this.

Whenever I make a scrollyteller, the first panel is always the 2nd of type... not the first of type and I have to change this in the css every time..... 

Am I just making scrollytellers wrong, or should this be the correct css code?

![TEST_climate_part_2_-_ABC_News__Australian_Broadcasting_Corporation_](https://user-images.githubusercontent.com/437566/68098399-2eb5d300-ff08-11e9-92e7-d796a6478998.png)

I know @drzax has seen this problem before. It results in the first panel being half way down the page instead of under the fold of the scrolly stage. @colingourlay have you had any issues with this? @nathanhoad request for comment too if you're free :)