### PR TITLE
Chrome panel fix

### DIFF
--- a/src/Panel/index.scss
+++ b/src/Panel/index.scss
@@ -69,6 +69,9 @@
     display: block;
     margin: auto;
   }
+
+  // Chrome fix https://stackoverflow.com/a/28906246/955917
+  -webkit-transform: translate3d(0,0,0);
 }
 
 .light {

--- a/src/Scrollyteller/index.scss
+++ b/src/Scrollyteller/index.scss
@@ -7,6 +7,9 @@
   * {
     box-sizing: border-box;
   }
+
+  // Chrome fix https://stackoverflow.com/a/28906246/955917
+  -webkit-transform: translate3d(0,0,0);
 }
 
 .graphic {


### PR DESCRIPTION
Stops Scrollyteller panels from going behind the stage on Chrome/Blink/Webkit browsers.