### PR TITLE
Fix state not being up to date inside onMarker callback

### DIFF
--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -48,51 +48,6 @@ const Scrollyteller = (props: Props) => {
     references.push({ panel, element });
   }
 
-  function onScroll(_event: any, dontFireInitialMarker?: boolean) {
-    const { config } = props;
-
-    if (references.length === 0) return;
-
-    // Work out which panel is the current one
-    const fold =
-      window.innerHeight * (config.waypoint ? config.waypoint / 100 : 0.8);
-    const referencesAboveTheFold = references.filter((r: any) => {
-      if (!r.element) return false;
-      const box = r.element.getBoundingClientRect();
-      return box.height !== 0 && box.top < fold;
-    });
-
-    let closestReference =
-      referencesAboveTheFold[referencesAboveTheFold.length - 1];
-    if (!closestReference) closestReference = references[0];
-
-    if (currentPanel !== closestReference.panel) {
-      currentPanel = closestReference.panel;
-      if (!dontFireInitialMarker) {
-        onMarkerRef.current(
-          closestReference.panel.config,
-          closestReference.panel.id
-        );
-      }
-    }
-
-    // Work out if the background should be fixed or not
-    if (base.current) {
-      const bounds = base.current.getBoundingClientRect();
-
-      let sticky;
-      if (bounds.top > 0) {
-        sticky = 'before';
-      } else if (bounds.bottom < window.innerHeight) {
-        sticky = 'after';
-      } else {
-        sticky = 'during';
-      }
-
-      setBackgroundAttachment(sticky);
-    }
-  }
-
   useEffect(() => {
     // Safari tries to do things before styling has kicked in
     // so lets wait for a split second before measuring.
@@ -114,6 +69,51 @@ const Scrollyteller = (props: Props) => {
     return () => {
       window.removeEventListener('scroll', onScroll);
     };
+
+    function onScroll(_event: any, dontFireInitialMarker?: boolean) {
+      const { config } = props;
+
+      if (references.length === 0) return;
+
+      // Work out which panel is the current one
+      const fold =
+        window.innerHeight * (config.waypoint ? config.waypoint / 100 : 0.8);
+      const referencesAboveTheFold = references.filter((r: any) => {
+        if (!r.element) return false;
+        const box = r.element.getBoundingClientRect();
+        return box.height !== 0 && box.top < fold;
+      });
+
+      let closestReference =
+        referencesAboveTheFold[referencesAboveTheFold.length - 1];
+      if (!closestReference) closestReference = references[0];
+
+      if (currentPanel !== closestReference.panel) {
+        currentPanel = closestReference.panel;
+        if (!dontFireInitialMarker) {
+          onMarkerRef.current(
+            closestReference.panel.config,
+            closestReference.panel.id
+          );
+        }
+      }
+
+      // Work out if the background should be fixed or not
+      if (base.current) {
+        const bounds = base.current.getBoundingClientRect();
+
+        let sticky;
+        if (bounds.top > 0) {
+          sticky = 'before';
+        } else if (bounds.bottom < window.innerHeight) {
+          sticky = 'after';
+        } else {
+          sticky = 'during';
+        }
+
+        setBackgroundAttachment(sticky);
+      }
+    }
   }, []);
 
   // RENDER

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -4,11 +4,13 @@ import Panel from '../Panel';
 import panelStyles from '../Panel/index.module.scss';
 import styles from './index.module.scss';
 
+type OnMarkerCallback = (config: any, id: string) => void;
+
 interface Props {
   children: any;
   panels: any[];
   config?: any;
-  onMarker?: (config: any, id: string) => void;
+  onMarker?: OnMarkerCallback;
   className?: string;
   panelClassName?: string;
   firstPanelClassName?: string;
@@ -35,7 +37,7 @@ const Scrollyteller = (props: Props) => {
   // This happens because useEffects attaching event listeners
   // is executed only once, meaning that state inside callbacks (onMarker)
   // will always have intial values.
-  const onMarkerRef = useRef(null);
+  const onMarkerRef = useRef<OnMarkerCallback | undefined>(props.onMarker);
   useEffect(() => {
     onMarkerRef.current = props.onMarker;
   });
@@ -91,10 +93,11 @@ const Scrollyteller = (props: Props) => {
       if (currentPanel !== closestReference.panel) {
         currentPanel = closestReference.panel;
         if (!dontFireInitialMarker) {
-          onMarkerRef.current(
-            closestReference.panel.config,
-            closestReference.panel.id
-          );
+          onMarkerRef.current &&
+            onMarkerRef.current(
+              closestReference.panel.config,
+              closestReference.panel.id
+            );
         }
       }
 

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -30,6 +30,16 @@ const Scrollyteller = (props: Props) => {
 
   const base = useRef<HTMLDivElement>(null);
 
+  // Create and update onMarkerRef to make sure state inside
+  // the onMarker callback is up to date.
+  // This happens because useEffects attaching event listeners
+  // is executed only once, meaning that state inside callbacks (onMarker)
+  // will always have intial values.
+  const onMarkerRef = useRef(null);
+  useEffect(() => {
+    onMarkerRef.current = props.onMarker;
+  });
+
   let currentPanel: any = null;
   const [backgroundAttachment, setBackgroundAttachment] = useState('before');
 
@@ -39,7 +49,7 @@ const Scrollyteller = (props: Props) => {
   }
 
   function onScroll(_event: any, dontFireInitialMarker?: boolean) {
-    const { config, onMarker } = props;
+    const { config } = props;
 
     if (references.length === 0) return;
 
@@ -59,8 +69,10 @@ const Scrollyteller = (props: Props) => {
     if (currentPanel !== closestReference.panel) {
       currentPanel = closestReference.panel;
       if (!dontFireInitialMarker) {
-        onMarker &&
-          onMarker(closestReference.panel.config, closestReference.panel.id);
+        onMarkerRef.current(
+          closestReference.panel.config,
+          closestReference.panel.id
+        );
       }
     }
 


### PR DESCRIPTION
* Add `onMarkerRef` https://github.com/abcnews/scrollyteller/commit/bfa13e156071e5141f2463400f56f62260c7ecb1
* Move `onScroll` inside `useEffects` https://github.com/abcnews/scrollyteller/commit/6f41a120c7fd1101d13fb2c6d87261623e7c7521



Closes https://github.com/abcnews/scrollyteller/issues/18