### PR TITLE
onProgress

### DIFF
--- a/example/public/desktop.html
+++ b/example/public/desktop.html
@@ -225,7 +225,7 @@
                 deserunt adipisicing deserunt eu cupidatat cupidatat elit irure
                 proident veniam.
               </p>
-              <a name="scrollytellerNUMBER0"></a>
+              <a name="scrollytellerNUMBER1"></a>
               <p>
                 Excepteur mollit exercitation cupidatat elit. Est aliqua sunt
                 nisi et. Consequat dolore eu mollit culpa est esse amet ipsum
@@ -244,7 +244,7 @@
                 nisi et. Consequat dolore eu mollit culpa est esse amet ipsum
                 dolore enim irure non irure deserunt.
               </p>
-              <a name="markNUMBER1"></a>
+              <a name="markNUMBER2"></a>
               <p>
                 Pariatur nisi magna tempor ea. Laborum commodo ea ipsum
                 pariatur. Exercitation dolore eiusmod adipisicing id veniam qui
@@ -253,7 +253,7 @@
                 sint aliquip dolore excepteur fugiat ipsum. Duis consequat anim
                 labore commodo.
               </p>
-              <a name="markNUMBER2"></a>
+              <a name="markNUMBER3"></a>
               <p>
                 Esse velit aliqua anim aliqua mollit elit elit sit consequat
                 mollit. Dolore fugiat ipsum voluptate voluptate cupidatat culpa
@@ -271,7 +271,7 @@
                 reprehenderit. Adipisicing cupidatat enim enim nulla irure eu
                 elit Lorem occaecat enim.
               </p>
-              <a name="markNUMBER3"></a>
+              <a name="markNUMBER4"></a>
               <p>
                 Qui sunt anim duis elit aute in amet elit non id nostrud. Duis
                 sit est nulla excepteur. Velit culpa duis exercitation non
@@ -284,7 +284,7 @@
                 ipsum qui. Dolor occaecat commodo anim eiusmod esse deserunt
                 esse. Sit magna cillum ullamco nulla in ex Lorem minim.
               </p>
-              <a name="markNUMBER4"></a>
+              <a name="markNUMBER5"></a>
               <p>
                 Cillum amet magna sunt exercitation ipsum occaecat id do
                 cupidatat laborum elit eu consequat. Id enim ullamco elit

--- a/example/src/components/AppOdyssey/index.tsx
+++ b/example/src/components/AppOdyssey/index.tsx
@@ -14,14 +14,20 @@ interface AppProps {
 
 const App: React.FC<AppProps> = ({ scrollyTellerDefinition }) => {
   const [config, setConfig] = useState<MarkerConfig>(null!);
+  const [progress, setProgress] = useState<number>(null!);
+
   return (
     <Scrollyteller<MarkerConfig>
       panels={scrollyTellerDefinition.panels}
-      onMarker={(config) => setConfig(config)}
+      onMarker={(config, id) => setConfig(config)}
+      onProgress={(progress) => setProgress(progress)}
     >
       <div className={styles.root}>
         <Worm />
-        <h1>{config && config.number}</h1>
+        <h1>
+          Mark number {config && config.number} <br />
+          at {(progress * 100).toFixed(2)}% progress
+        </h1>
       </div>
     </Scrollyteller>
   );

--- a/example/src/components/AppVanilla/index.tsx
+++ b/example/src/components/AppVanilla/index.tsx
@@ -12,29 +12,36 @@ type MarkerConfig = {
   number: number;
 };
 
+const text = loremIpsum({ count: 7, units: 'paragraph' });
+const pars = text.split('\n').map((t, i) => <p key={i}>{t}</p>);
+const panels = text.split('\n').map((t, i) => {
+  const p = document.createElement('p');
+  p.textContent = t;
+  return {
+    id: i,
+    config: { id: i, number: i + 1 },
+    nodes: [p],
+  };
+});
+
 const App: React.FC<AppProps> = ({ projectName }) => {
   const [config, setConfig] = useState<MarkerConfig>(null!);
-  const text = loremIpsum({ count: 7, units: 'paragraph' });
-  const pars = text.split('\n').map((t, i) => <p key={i}>{t}</p>);
-  const panels = text.split('\n').map((t, i) => {
-    const p = document.createElement('p');
-    p.textContent = t;
-    return {
-      id: i,
-      config: { id: i, number: i + 1 },
-      nodes: [p],
-    };
-  });
+  const [progress, setProgress] = useState<number>(null!);
+
   return (
     <>
       {pars}
       <Scrollyteller<MarkerConfig>
         panels={panels}
         onMarker={(config) => setConfig(config)}
+        onProgress={(progress) => setProgress(progress)}
       >
         <div className={styles.root}>
           <Worm />
-          <h1>{config && config.number}</h1>
+          <h1>
+            Mark number {config && config.number} <br />
+            at {(progress * 100).toFixed(2)}% progress
+          </h1>
         </div>
       </Scrollyteller>
       {pars}

--- a/src/Panel/index.tsx
+++ b/src/Panel/index.tsx
@@ -46,7 +46,7 @@ const Panel: React.FC<PanelProps> = ({
         base.current && base.current.removeChild(node);
       });
     };
-  }, [base.current]);
+  }, []);
 
   const mergedClassName = [
     className.replace(/\s+/, '') !== '' ? className : styles.base,

--- a/src/Scrollyteller/functions.ts
+++ b/src/Scrollyteller/functions.ts
@@ -1,0 +1,12 @@
+export const uglyTwitterHack = (selector: string) => {
+  [].slice
+    .call(document.querySelectorAll(`${selector} .twitter-tweet-rendered`))
+    .forEach((card: HTMLElement) => {
+      card.style.setProperty('width', '100%');
+    });
+};
+
+export const cn = (candidates: (undefined | null | false | string)[]) =>
+  candidates
+    .filter((x: undefined | null | false | string): boolean => !!x)
+    .join(' ');

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -66,7 +66,7 @@ const Scrollyteller = <T,>({
   const onMarkerRef = useRef(onMarker);
   useEffect(() => {
     onMarkerRef.current = onMarker;
-  });
+  }, [onMarker]);
 
   let currentPanel: PanelDefinition<T> | null = null;
   const [backgroundAttachment, setBackgroundAttachment] = useState('before');

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -188,6 +188,4 @@ const Scrollyteller = <T,>({
   );
 };
 
-Scrollyteller.displayName = 'Scrollyteller';
-
 export default Scrollyteller;


### PR DESCRIPTION
Adds an option for an `onProgress` callback which can be used to respond to progress within 
each panel.

`progress` will be:
- negative before the first mark is reached
- between 0 and 1 for each panel
- greater than 1 after the bottom of the last panel is scrolled past


Commits:

- Remove redundant displayName property
- Ensure the onMarker callback can be updated
- Add onProgress callback prop
