### PR TITLE
Make it possible to configure colours with CSS vars

### DIFF
--- a/src/Panel/index.module.scss
+++ b/src/Panel/index.module.scss
@@ -25,7 +25,7 @@
   &::before {
     content: '';
 
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: var(--color-panel-background) rgba(0, 0, 0, 0.6);
     border-radius: 2px;
 
     position: absolute;
@@ -48,7 +48,7 @@
     font-family: ABCSerif, Book Antiqua, Palatino Linotype, Palatino, serif;
     font-size: 1.375rem;
     line-height: 1.666666667;
-    color: #fefefe;
+    color: var(--color-panel-text) #fefefe;
 
     padding-left: 0.875rem;
     padding-right: 0.875rem;
@@ -76,11 +76,11 @@
 
 .light {
   &::before {
-    background-color: hsla(0, 0%, 100%, 0.9);
+    background-color: var(--color-panel-background) hsla(0, 0%, 100%, 0.9);
   }
 
   p {
-    color: #111;
+    color: var(--color-panel-text) #111;
   }
 }
 

--- a/src/Scrollyteller/index.tsx
+++ b/src/Scrollyteller/index.tsx
@@ -264,6 +264,7 @@ const Scrollyteller = <T,>({
       </>
     );
   }, [
+    theme,
     panels,
     firstPanelClassName,
     lastPanelClassName,


### PR DESCRIPTION
It might be useful to be able to configure panel colours with CSS, so now you can.

This also fixes a bug where changes to the theme would not have been rendered. 
Ultimately it might be best to deprecate the theme property.

Commits:

- 🐛 make sure panels are updated if the theme changes
- Make panel colours configurable